### PR TITLE
Add ClusterFuzzLite integration

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+COPY . $SRC/csv_parser
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/csv_parser

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,4 @@
+# ClusterFuzzLite set up
+
+This folder contains a fuzzing set for [ClusterFuzzLite](https://google.github.io/clusterfuzzlite).
+        

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -eu
+
+# Copy all fuzzer executables to $OUT/
+$CC $CFLAGS $LIB_FUZZING_ENGINE \
+  $SRC/csv_parser/.clusterfuzzlite/parse_fuzzer.c \
+  -o $OUT/parse_fuzzer \
+  csv.c split.c fread_csv_line.c \
+  -I$SRC/csv_parser

--- a/.clusterfuzzlite/parse_fuzzer.c
+++ b/.clusterfuzzlite/parse_fuzzer.c
@@ -1,0 +1,23 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <csv.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  char *new_str = (char *)malloc(size + 1);
+  if (new_str == NULL) {
+    return 0;
+  }
+  memcpy(new_str, data, size);
+  new_str[size] = '\0';
+
+  char **pstr = parse_csv(new_str);
+  if (pstr != NULL) {
+    free_csv_line(pstr);
+  }
+
+  free(new_str);
+  return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -2,7 +2,7 @@ name: ClusterFuzzLite PR fuzzing
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 permissions: read-all
 jobs:
   PR:

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

I added a fuzzer that targets `parse_csv`, and currently set the timeout of CFLite to 100 seconds. CFLite will flag if the fuzzer finds  any issues in the code introduced by a PR.

If you'd like to test this the way ClusteFuzzLite will run it you an use the following commands:

```sh
git clone https://github.com/google/oss-fuzz
git clone https://github.com/DavidKorczynski/csv_parser csv_parser
cd csv_parser
git checkout clusterfuzzlite

# Build the fuzzers in .clusterfuzzlite
python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD

# Run the fuzzer for 10 seconds
python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD parse_fuzzer -- -max_total_time=10
```